### PR TITLE
2.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Send a report about user MFA status in Microsoft Entra. The e-mail content only 
 | ------ | --------- | ------------------------------------------------------------ | -------- | --------------- |
 | String[] | EmailAddress        | E-mail to who should receive the report. Defaults to logged-in user in Microsoft Entra. | True     | abc@contoso.com |
 | String | From        | E-mail to send from, the e-mail address must exist in the Microsoft 365 tenant. | false     | from@contoso.com |
+| String | Subject     | Subject of the e-mail. Defaults to "Microsoft Entra MFA Report". | True     | N/A             |
+| String | OutputFileName | Name of the output file attached to the e-mail, defaults to "MFAReport.csv". | True     | N/A             |
 
 #### Example(s)
 
@@ -119,10 +121,11 @@ Get all users and if they are targeted by a Entra Conditional Access that requir
 
 #### Parameter(s)
 
-| Type   | Parameter         | Description                                    | Optional | Accepted Values |
-| ------ | ----------------- | ---------------------------------------------- | -------- | --------------- |
-| String | UserPrincipalName | If not specified, all users are returned.      | True     | abc@contoso.com |
-| Switch | OnlyEnabled       | If specified, only enabled users are returned. | True     | N/A             |
+| Type     | Parameter         | Description                                    | Optional | Accepted Values |
+| ------   | ----------------- | ---------------------------------------------- | -------- | --------------- |
+| String   | UserPrincipalName | If not specified, all users are returned.      | True     | abc@contoso.com |
+| Switch   | OnlyEnabled       | If specified, only enabled users are returned. | True     | N/A             |
+| String[] | ExemptGroups      | Exempt groups to flag users in the report (users that are members of any of the specified groups will be flagged in the report as exempt from MFA). | True     | MS_NO_MFA_TRUSTED_CLOUD, MS_NO_MFA_TRUSTED |
 
 #### Example(s)
 
@@ -261,13 +264,13 @@ Array
   ```powershell
     # Get all installed modules.
     $installedModules = Get-InstalledModule;
-  
+
     # Foreach install module.
     foreach ($installedModule in $installedModules)
     {
         # Get all versions.
         $versions = Get-InstalledModule -Name $installedModule.Name -AllVersions;
-  
+
         # Foreach version.
         foreach ($version in $versions)
         {
@@ -281,7 +284,7 @@ Array
                     -Confirm:$false `
                     -ErrorAction Stop `
                     -WarningAction SilentlyContinue;
-  
+
                 # Write to log.
                 Write-Information `
                     -Message ("[SUCCESS] Removed module '{0}' version '{1}'" -f $version.Name, $version.Version) `
@@ -305,12 +308,12 @@ Array
   ```powershell
   # Managed Identity Display Name.
   $managedIdentityObjectId = 'OBJECT ID OF THE MANAGED IDENTITY';
-  
+
   # Connect to Microsoft Graph (delegated permissions).
   Connect-MgGraph `
       -Scopes @('Directory.ReadWrite.All', 'AppRoleAssignment.ReadWrite.All') `
       -ContextScope Process;
-  
+
   # Required Microsoft Graph API scopes.
   $graphApiScopes = @(
        'Policy.Read.All',
@@ -323,15 +326,15 @@ Array
        'AuditLog.Read.All',
        'Mail.Send'
   );
-  
+
   # Get managed identity.
   $managedIdentity = Get-MgServicePrincipal `
       -Filter "Id eq '$managedIdentityObjectId'";
-  
+
   # Get Graph Service Principal.
   $graphSPN = Get-MgServicePrincipal `
       -Filter "AppId eq '00000003-0000-0000-c000-000000000000'";
-  
+
   # Foreach required permission, assign to managed identity.
   foreach ($graphApiScope in $graphApiScopes)
   {
@@ -339,28 +342,28 @@ Array
       $appRole = $graphSPN.AppRoles |
           Where-Object { $_.Value -eq $graphApiScope } |
               Where-Object { $_.AllowedMemberTypes -contains 'Application' };
-  
+
       # If app role not found.
       if ($null -eq $appRole)
       {
           # Continue to next permission.
           continue;
       }
-  
+
       # Create app role assignment.
       $bodyParam = @{
           PrincipalId = $managedIdentity.Id
           ResourceId  = $graphSPN.Id
           AppRoleId   = $appRole.Id
       }
-  
+
       # Assign app role to managed identity.
       New-MgServicePrincipalAppRoleAssignment `
           -ServicePrincipalId $managedIdentity.Id `
           -BodyParameter $bodyParam;
   }
   ```
-  
+
 - **If you need to install the required modules into a Azure Automation Account, use the following:**
 
    ```powershell
@@ -368,10 +371,10 @@ Array
    $subscriptionId = 'xxxxxx-xxxxxx-xxxx-xxxx-xxxxxxxxxx';
    $resourceGroupName = 'resourceGroupName';
    $automationAccountName = 'automationAccountName';
-   
+
    # Install module.
    Install-Module -Name 'Az.Accounts', 'Az.Automation' -Scope CurrentUser -Force -AllowClobber;
-   
+
    # Modules to install.
    $modulesToInstall = @{
        'Microsoft.Entra'                                = '1.0.12';
@@ -393,26 +396,26 @@ Array
        'Microsoft.Graph.Reports'                        = '2.25.0';
        'Microsoft.Graph.Users'                          = '2.25.0';
        'Microsoft.Graph.Users.Actions'                  = '2.25.0';
-       'SystemAdmins.MsMfaToolbox'                      = '2.0.6';
+       'SystemAdmins.MsMfaToolbox'                      = '2.0.7';
    };
-   
+
    # Connect to Azure account.
    Connect-AzAccount -Subscription $subscriptionId;
-   
+
    # Foreach module.
    foreach ($moduleToInstall in $modulesToInstall.GetEnumerator())
    {
        # Get module name and version.
        $moduleName = $moduleToInstall.Key;
        $moduleVersion = $moduleToInstall.Value;
-   
-   
+
+
        # Try to install module.
        try
        {
            # Install module.
            New-AzAutomationModule -AutomationAccountName $automationAccountName -ResourceGroupName $resourceGroupName -Name $moduleName -ContentLinkUri "https://www.powershellgallery.com/api/v2/package/$moduleName/$moduleVersion" -RuntimeVersion '7.2' -ErrorAction Stop;
-   
+
            # Write to host.
            Write-Host "Module $moduleName version $moduleVersion installed successfully";
        }
@@ -423,7 +426,7 @@ Array
            Write-Host "Module $moduleName version $moduleVersion could not be installed";
        }
    }
-   
+
    ```
 
-   
+

--- a/src/SystemAdmins.MsMfaToolbox/SystemAdmins.MsMfaToolbox.psd1
+++ b/src/SystemAdmins.MsMfaToolbox/SystemAdmins.MsMfaToolbox.psd1
@@ -3,7 +3,7 @@
     RootModule           = 'SystemAdmins.MsMfaToolbox.psm1';
 
     # Version number of this module.
-    ModuleVersion        = '2.0.6';
+    ModuleVersion        = '2.0.7';
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core');

--- a/src/SystemAdmins.MsMfaToolbox/private/assets/send-eidusermfareport/header.html
+++ b/src/SystemAdmins.MsMfaToolbox/private/assets/send-eidusermfareport/header.html
@@ -75,7 +75,8 @@
         </div>
         <div class="content">
             <p>##SecurityDefaultsInfo##</p>
-            <p>Please audit the following ##UsersCount## internal accounts as they are not fully covered by MFA.</p>
+            <p>Please audit the following ##UsersCount## (only user type "internal" below) accounts as they are not fully covered by MFA.</p>
+            <p>If exempt groups were included, they will not appear in the findings below (but visible in the attached file in column "MemberOfExemptGroup").</p>
             <p>More information can be found in the file attached to this e-mail.</p>
             <p><b>Last updated</b>: ##DATE##</p>
             <table>

--- a/src/SystemAdmins.MsMfaToolbox/public/entraid/Get-EidUserMfaPolicy.ps1
+++ b/src/SystemAdmins.MsMfaToolbox/public/entraid/Get-EidUserMfaPolicy.ps1
@@ -10,6 +10,8 @@ function Get-EidUserMfaPolicy
         If not specified, all users are returned.
     .PARAMETER OnlyEnabled
         If specified, only enabled users are returned.
+    .PARAMETER ExemptGroups
+        Exempt groups to flag users in the report (users that are members of any of the specified groups will be flagged in the report as exempt from MFA).
     .EXAMPLE
         Get-EidUserMfaPolicy;
     #>
@@ -25,7 +27,11 @@ function Get-EidUserMfaPolicy
 
         # Only enabled users.
         [Parameter(Mandatory = $false, Position = 1, ValueFromPipelineByPropertyName = $true)]
-        [switch]$OnlyEnabled
+        [switch]$OnlyEnabled,
+
+        # Exempt groups to flag users in the report (users that are members of any of the specified groups will be flagged in the report as exempt from MFA).
+        [Parameter(Mandatory = $false)]
+        [string[]]$ExemptGroups
     )
 
     begin
@@ -58,11 +64,31 @@ function Get-EidUserMfaPolicy
             $entraUsers = (Get-EntraUser -Property $entraUserProperties -All);
         }
 
+        # Object for storing exempt group members.
+        $exemptGroupMembers = @();
+
         # Object array to store users.
         $result = @();
     }
     process
     {
+        # Foreach exempt group.
+        foreach ($exemptGroup in $ExemptGroups)
+        {
+            # Get group ID by display name.
+            $exemptGroupIds = (Get-MgGroup -Filter ("displayName eq '{0}'" -f $exemptGroup) -Select Id).Id;
+
+            # Write to log.
+            Write-CustomLog -Message ("Found {0} exempt group(s) with display name '{1}'" -f $exemptGroupIds.Count, $exemptGroup) -Level 'Verbose';
+
+            # For each group ID.
+            foreach ($exemptGroupId in $exemptGroupIds)
+            {
+                # Get group members.
+                $exemptGroupMembers += Get-EidGroupTransitiveMember -Id $exemptGroupId;
+            }
+        }
+
         # Foreach Entra user.
         foreach ($entraUser in $entraUsers)
         {
@@ -148,6 +174,7 @@ function Get-EidUserMfaPolicy
                 ConditionalAccessPolicy = ($policiesTargetingUser).DisplayName;
                 IsProtected             = $false;
                 HasMailbox              = $false;
+                MemberOfExemptGroup     = $false;
             };
 
             # If the user is not a guest.
@@ -230,6 +257,16 @@ function Get-EidUserMfaPolicy
             {
                 # Write to log.
                 Write-CustomLog -Message ("User '{0}' is NOT protected by MFA" -f $entraUser.UserPrincipalName) -Level 'Verbose';
+            }
+
+            # If the user is a member of any of the specified exempt groups.
+            if ($entraUser.UserPrincipalName -in $exemptGroupMembers)
+            {
+                # Write to log.
+                Write-CustomLog -Message ("User '{0}' is a member of an exempt group" -f $entraUser.UserPrincipalName) -Level 'Verbose';
+
+                # Set MemberOfExemptGroup to true.
+                $user.MemberOfExemptGroup = $true;
             }
 
             # Add the user to the object array.

--- a/src/SystemAdmins.MsMfaToolbox/public/entraid/Send-EidUserMfaReport.ps1
+++ b/src/SystemAdmins.MsMfaToolbox/public/entraid/Send-EidUserMfaReport.ps1
@@ -11,6 +11,8 @@ function Send-EidUserMfaReport
         The from e-mail address.
     .PARAMETER Subject
         Subject used in the e-mail.
+    .PARAMETER OutputFileName
+        Output file name for the report (must end in .csv).
     .EXAMPLE
         Send-EidUserMfaReport -EmailAddress 'abc@contoso.com';
     .EXAMPLE
@@ -19,6 +21,9 @@ function Send-EidUserMfaReport
     .EXAMPLE
         # Send e-mail with specific subject.
         Send-EidUserMfaReport -Subject "Contoso M365 MFA Findings" -EmailAddress 'to@contoso.com';
+    .EXAMPLE
+        # Specify output file name.
+        Send-EidUserMfaReport -OutputFileName "CustomReportName.csv" -EmailAddress 'to@contoso.com';
     #>
     [cmdletbinding()]
     [OutputType([void])]
@@ -36,7 +41,16 @@ function Send-EidUserMfaReport
         # E-mail address to send from (e-mail must exist in the tenant).
         [Parameter(Mandatory = $false)]
         [ValidateScript({ Test-EmailAddress -InputObject $_ })]
-        [string]$From
+        [string]$From,
+
+        # Output file name for the report (must end in .csv).
+        [Parameter(Mandatory = $false)]
+        [ValidateScript({ $_ -like '*.csv' })]
+        [string]$OutputFileName = ('Microsoft 365 User MFA Status Report - {0}.csv' -f (Get-Date -Format 'yyyy-MM-dd')),
+
+        # Exempt groups to flag users in the report (users that are members of any of the specified groups will be flagged in the report as exempt from MFA).
+        [Parameter(Mandatory = $false)]
+        [string[]]$ExemptGroups
     )
 
     begin
@@ -84,17 +98,14 @@ function Send-EidUserMfaReport
         # Temporary folder path.
         [string]$tempFolderPath = [System.IO.Path]::GetTempPath();
 
-        # File name.
-        [string]$outputFileName = ('Microsoft 365 User MFA Status Report - {0}.csv' -f (Get-Date -Format 'yyyy-MM-dd'));
-
         # Output file path.
-        [string]$outputFilePath = Join-Path -Path $tempFolderPath -ChildPath $outputFileName;
+        [string]$outputFilePath = Join-Path -Path $tempFolderPath -ChildPath $OutputFileName;
+
+        # Counter for users.
+        [int]$userCount = 0;
     }
     process
     {
-        # Counter for users.
-        [int]$userCount = 0;
-
         # Foreach user.
         foreach ($user in $users)
         {
@@ -114,6 +125,13 @@ function Send-EidUserMfaReport
 
             # If the account is disabled.
             if ($false -eq $user.AccountEnabled)
+            {
+                # Continue to next user.
+                continue;
+            }
+
+            # If the user is exempt from MFA based on group membership.
+            if ($user.MemberOfExemptGroup -eq $true)
             {
                 # Continue to next user.
                 continue;
@@ -142,7 +160,8 @@ function Send-EidUserMfaReport
         Write-CustomLog -Message ("Exporting report to '{0}'" -f $outputFilePath) -Level 'Verbose';
 
         # Save status report as CSV.
-        $null = $users | Select-Object -Property Id,
+        $null = $users | Select-Object -Property `
+            Id,
         UserPrincipalName,
         DisplayName,
         AccountEnabled,
@@ -152,6 +171,7 @@ function Send-EidUserMfaReport
         LastSuccessfulSignIn,
         @{ Name = 'ConditionalAccessPolicy'; Expression = { $_.ConditionalAccessPolicy -join '|' } },
         IsProtected,
+        MemberOfExemptGroup,
         Mailbox | Export-Csv -Path $outputFilePath -UseQuotes Always -Encoding utf8 -Delimiter ';' -Force;
 
         # Convert CSV to Base64.


### PR DESCRIPTION
This pull request adds support for specifying "exempt groups" whose members should be flagged as exempt from MFA in user reports, and introduces new customization options for the generated report, such as specifying the output file name. It also improves the clarity of the email report and updates documentation and module versioning accordingly.

**Support for exempt groups in MFA reports:**
* Added a new `ExemptGroups` parameter to `Get-EidUserMfaPolicy` and `Send-EidUserMfaReport` to flag users who are members of specified groups as exempt from MFA, and included this information in both the CSV and HTML reports.
* Updated the email report header to clarify that exempt group members are excluded from the HTML findings but are visible in the attached CSV file.

**Report customization improvements:**
* Added an `OutputFileName` parameter to `Send-EidUserMfaReport` to allow specifying the name of the output CSV file.

**Versioning and dependency updates:**
* Bumped the module version from `2.0.6` to `2.0.7` in both the manifest and the README dependency list.